### PR TITLE
RESTWS-911: Correcting the misleading REST docs for /session endpoint

### DIFF
--- a/source/includes/auth.md
+++ b/source/includes/auth.md
@@ -93,13 +93,7 @@ fetch("/openmrs/ws/rest/v1/session", requestOptions)
 }
 ```
 
- 
-
-* The session token is retrieved using Basic authentication on the `/session` endpoint. The response will include a `JSESSIONID` in the header. This session ID is also included in the response object
-
-
-
-* The session token is retrieved using Basic authentication on the `/session` endpoint. The response will include a `JSESSIONID` in the header. This session ID is also included in the response object
+* The session token is retrieved using Basic authentication on the `/session` endpoint. The response will include a `JSESSIONID` in the header.
 
 
 * The `sessionId` token should be passed with all subsequent calls as a cookie named `JSESSIONID`.


### PR DESCRIPTION

This is a correction for https://openmrs.atlassian.net/browse/RESTWS-911:
`According to the REST docs [here](https://rest.openmrs.org/#authentication:~:text=Admin123%20is%20YWRtaW46QWRtaW4xMjM%3D-,Retrieve%20session%20token,-Retrieve%20session%20token) <sessionid> is returned as a parameter of the response object from the </session> endpoint but It was removed due to a security vulnerability. This could be misleading.`